### PR TITLE
update repository links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Following these guidelines helps to communicate that you respect the time of the
 
 ## Using the issue tracker
 
-The [issue tracker](https://github.com/gretzky/locale-tools/issues) is the preferred channel for bug reports and feature requests. If you're submitting a pull request, it's helpful to either make sure an issue exists in the tracker, or create one for your change.
+The [issue tracker](https://github.com/gretzky/iso-locale-tools/issues) is the preferred channel for bug reports and feature requests. If you're submitting a pull request, it's helpful to either make sure an issue exists in the tracker, or create one for your change.
 
 ## Bug reports
 
@@ -24,7 +24,7 @@ Please try to be as detailed as possible in your bug report - the more details, 
 
 Feature requests are welcome, especially if they are related to open issues.
 
-**Before opening a pull request**, please take a moment to find out whether your idea fits within the scope and aims of this project. Please [open a new feature request](https://github.comgretzky/locale-tools/issues/new) and fill in the template that appears. This will help developers understand your intent and may prevent you from spending a lot of time and effort working on something that may not get merged.
+**Before opening a pull request**, please take a moment to find out whether your idea fits within the scope and aims of this project. Please [open a new feature request](https://github.comgretzky/iso-locale-tools/issues/new) and fill in the template that appears. This will help developers understand your intent and may prevent you from spending a lot of time and effort working on something that may not get merged.
 
 Guidelines for feature requests:
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/gretzky/locale-tools.git"
+    "url": "https://github.com/gretzky/iso-locale-tools.git"
   },
   "author": "Sara Pope <sarafpope@gmail.com>",
   "license": "MIT",

--- a/packages/countries/package.json
+++ b/packages/countries/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gretzky/locale-tools.git",
+    "url": "git+https://github.com/gretzky/iso-locale-tools.git",
     "directory": "packages/countries"
   },
   "keywords": [

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gretzky/locale-tools.git",
+    "url": "git+https://github.com/gretzky/iso-locale-tools.git",
     "directory": "packages/currency"
   },
   "keywords": [

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gretzky/locale-tools.git",
+    "url": "git+https://github.com/gretzky/iso-locale-tools.git",
     "directory": "packages/datetime"
   },
   "keywords": [

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gretzky/locale-tools.git",
+    "url": "git+https://github.com/gretzky/iso-locale-tools.git",
     "directory": "packages/languages"
   },
   "keywords": [

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gretzky/locale-tools.git",
+    "url": "git+https://github.com/gretzky/iso-locale-tools.git",
     "directory": "packages/localization"
   },
   "keywords": [

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gretzky/locale-tools.git",
+    "url": "git+https://github.com/gretzky/iso-locale-tools.git",
     "directory": "packages/navigation"
   },
   "keywords": [


### PR DESCRIPTION
I noticed that your repository link on npmjs shows me an outdated link (because the repo has been renamed from "locale-tools" to "iso-locale-tools"), which is why I updated it.

**Screenshot of old link:**

![image](https://user-images.githubusercontent.com/469989/193799094-ac19b590-64ac-44f2-9a77-5a7a66d46216.png)
